### PR TITLE
fix: demote lifecycle logs

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -16,7 +16,7 @@
   "imports": {
     "@date-fns/utc": "npm:@date-fns/utc@^2.1.0",
     "@deno/dnt": "jsr:@deno/dnt@^0.41.3",
-    "@flowcore/sdk": "jsr:@flowcore/sdk@^1.78.0",
+    "@flowcore/sdk": "jsr:@flowcore/sdk@^4.2.2",
     "@flowcore/sdk-oidc-client": "npm:@flowcore/sdk-oidc-client@^1.3.1",
     "@flowcore/time-uuid": "jsr:@flowcore/time-uuid@^0.1.1",
     "@sinclair/typebox": "npm:@sinclair/typebox@0.32.15",

--- a/deno.lock
+++ b/deno.lock
@@ -5,8 +5,8 @@
     "jsr:@deno/cache-dir@~0.10.3": "0.10.3",
     "jsr:@deno/dnt@~0.41.3": "0.41.3",
     "jsr:@deno/graph@~0.73.1": "0.73.1",
-    "jsr:@flowcore/sdk@*": "1.78.0",
-    "jsr:@flowcore/sdk@^1.78.0": "1.78.0",
+    "jsr:@flowcore/sdk@4.2.2": "4.2.2",
+    "jsr:@flowcore/sdk@^4.2.2": "4.2.2",
     "jsr:@flowcore/time-uuid@~0.1.1": "0.1.2",
     "jsr:@std/assert@0.223": "0.223.0",
     "jsr:@std/assert@0.226": "0.226.0",
@@ -68,8 +68,8 @@
     "@deno/graph@0.73.1": {
       "integrity": "cd69639d2709d479037d5ce191a422eabe8d71bb68b0098344f6b07411c84d41"
     },
-    "@flowcore/sdk@1.78.0": {
-      "integrity": "1e1c5c7f2aa22f47a5093e324ba21547a451b1702a4a4d0f1bb5e5c8761ac0c9",
+    "@flowcore/sdk@4.2.2": {
+      "integrity": "1f62166e11376d6e7aafa572e072665ea2e7591497254abce4e8b13b7b5d166c",
       "dependencies": [
         "npm:@sinclair/typebox",
         "npm:rxjs"
@@ -206,7 +206,8 @@
       "integrity": "sha512-tOQCRCwC74DgBTk4pWZ9V45sk4d7peoE2njVprMRCBXrhJ5q5cYM7i6W+Uvw2qUrcfOSnuisrX7bEx3b3Wx4QA==",
       "dependencies": [
         "nkeys.js"
-      ]
+      ],
+      "deprecated": true
     },
     "nkeys.js@1.1.0": {
       "integrity": "sha512-tB/a0shZL5UZWSwsoeyqfTszONTt4k2YS0tuQioMOD180+MbombYVgzDUYHlx+gejYK6rgf08n/2Df99WY0Sxg==",
@@ -243,7 +244,7 @@
   "workspace": {
     "dependencies": [
       "jsr:@deno/dnt@~0.41.3",
-      "jsr:@flowcore/sdk@^1.78.0",
+      "jsr:@flowcore/sdk@^4.2.2",
       "jsr:@flowcore/time-uuid@~0.1.1",
       "jsr:@std/assert@^1.0.6",
       "jsr:@std/testing@^1.0.6",

--- a/src/data-pump/data-pump-cluster.ts
+++ b/src/data-pump/data-pump-cluster.ts
@@ -147,7 +147,7 @@ export class FlowcoreDataPumpCluster {
       logger: this.logger,
       onMessage: (msg) => this.handleWorkerMessage(msg, conn),
       onClose: () => {
-        this.logger?.info("Leader connection closed")
+        this.logger?.debug("Leader connection closed")
         this.leaderConnection = undefined
       },
     })
@@ -524,7 +524,7 @@ export class FlowcoreDataPumpCluster {
   }
 
   private connectToWorker(instanceId: string, address: string): void {
-    this.logger?.info("Connecting to worker", { instanceId, address })
+    this.logger?.debug("Connecting to worker", { instanceId, address })
 
     try {
       const ws = new WebSocket(address)
@@ -548,7 +548,7 @@ export class FlowcoreDataPumpCluster {
         workerConn.reconnectAttempts = 0
         this.workers.set(instanceId, workerConn)
         clusterMetrics.activeWorkersGauge.set(this.workers.size)
-        this.logger?.info("Connected to worker", { instanceId })
+        this.logger?.debug("Connected to worker", { instanceId })
       }
 
       ws.onerror = () => {
@@ -564,7 +564,7 @@ export class FlowcoreDataPumpCluster {
     const worker = this.workers.get(instanceId)
     if (!worker) return
 
-    this.logger?.info("Worker disconnected", { instanceId })
+    this.logger?.debug("Worker disconnected", { instanceId })
 
     // reject all pending deliveries - pump's ack timeout will handle reOpen
     worker.deliveryTracker.rejectAll(new Error("Worker disconnected"))

--- a/src/data-pump/notifier.ts
+++ b/src/data-pump/notifier.ts
@@ -129,7 +129,7 @@ export class FlowcoreNotifier {
         flowType: this.dataSource.flowType,
       },
       {
-        logger: this.options.logger ?? noOpLogger,
+        logger: createNotificationClientLogger(this.options.logger ?? noOpLogger),
         reconnectInterval: 1000,
       },
     )
@@ -164,6 +164,25 @@ export class FlowcoreNotifier {
       },
     }
   }
+}
+
+function createNotificationClientLogger(logger: FlowcoreLogger): FlowcoreLogger {
+  return {
+    debug: (message, metadata) => logger.debug(message, metadata),
+    info: (message, metadata) => {
+      if (isNormalNotificationLifecycleInfo(message)) {
+        logger.debug(message, metadata)
+        return
+      }
+      logger.info(message, metadata)
+    },
+    warn: (message, metadata) => logger.warn(message, metadata),
+    error: (message, metadata) => logger.error(message, metadata),
+  }
+}
+
+function isNormalNotificationLifecycleInfo(message: string): boolean {
+  return message === "WebSocket connection opened." || message.startsWith("Connection closed:")
 }
 
 /**

--- a/test/tests/data-pump-cluster.test.ts
+++ b/test/tests/data-pump-cluster.test.ts
@@ -2,7 +2,7 @@ import { assertEquals, assertRejects, assertThrows } from "@std/assert"
 import { beforeEach, describe, it } from "@std/testing/bdd"
 import type { FlowcoreEvent } from "@flowcore/sdk"
 import { FlowcoreDataPumpCluster } from "../../src/data-pump/data-pump-cluster.ts"
-import type { FlowcoreDataPumpCoordinator } from "../../src/data-pump/types.ts"
+import type { FlowcoreDataPumpCoordinator, FlowcoreLogger } from "../../src/data-pump/types.ts"
 import {
   DeliveryTracker,
   deserializeMessage,
@@ -91,6 +91,33 @@ class MockCoordinator implements FlowcoreDataPumpCoordinator {
 }
 
 // #endregion
+
+function createRecordingLogger(): FlowcoreLogger & { calls: Record<keyof FlowcoreLogger, string[]> } {
+  const calls: Record<keyof FlowcoreLogger, string[]> = {
+    debug: [],
+    info: [],
+    warn: [],
+    error: [],
+  }
+  return {
+    calls,
+    debug: (message) => calls.debug.push(message),
+    info: (message) => calls.info.push(message),
+    warn: (message) => calls.warn.push(message),
+    error: (message) => calls.error.push(String(message)),
+  }
+}
+
+function createFakeWebSocket(): WebSocket {
+  return {
+    readyState: WebSocket.OPEN,
+    send: () => {},
+    close: () => {},
+    onmessage: null,
+    onclose: null,
+    onerror: null,
+  } as unknown as WebSocket
+}
 
 // #region WS Protocol Tests
 
@@ -416,3 +443,32 @@ describe("Cluster Options Validation", () => {
 })
 
 // #endregion
+
+describe("Cluster lifecycle logging", () => {
+  it("logs leader connection close as debug, not info", () => {
+    const logger = createRecordingLogger()
+    const ws = createFakeWebSocket()
+    const cluster = new FlowcoreDataPumpCluster({
+      auth: { getBearerToken: () => Promise.resolve("fake") },
+      dataSource: {
+        tenant: "test",
+        dataCore: "dc",
+        flowType: "ft",
+        eventTypes: ["ev"],
+      },
+      stateManager: {
+        getState: () => null,
+      },
+      coordinator: new MockCoordinator(),
+      advertisedAddress: "ws://localhost:8080",
+      notifier: { type: "poller", intervalMs: 1000 },
+      logger,
+    })
+
+    cluster.handleConnection(ws)
+    ws.onclose?.(new CloseEvent("close"))
+
+    assertEquals(logger.calls.debug.includes("Leader connection closed"), true)
+    assertEquals(logger.calls.info.includes("Leader connection closed"), false)
+  })
+})

--- a/test/tests/notifier.test.ts
+++ b/test/tests/notifier.test.ts
@@ -4,6 +4,7 @@ import { stub } from "@std/testing/mock"
 import type { NotificationClient, NotificationEvent } from "@flowcore/sdk"
 import type { Subject } from "rxjs"
 import { _internals, FlowcoreNotifier } from "../../src/data-pump/notifier.ts"
+import type { FlowcoreLogger } from "../../src/data-pump/types.ts"
 
 // #region Test Helpers
 
@@ -12,6 +13,7 @@ const FAKE_API_KEY = "fc_testid_testsecret"
 interface FakeClientHandle {
   client: NotificationClient
   subject: Subject<NotificationEvent>
+  options: unknown
   connectCalls: number
   disconnectCalls: number
   // Triggers fired automatically as part of connect(). The factory runs each
@@ -34,11 +36,12 @@ function createFakeFactory(config: FakeFactoryConfig) {
     observer: Subject<NotificationEvent>,
     _auth: unknown,
     _spec: unknown,
-    _opts: unknown,
+    opts: unknown,
   ): NotificationClient => {
     const handle: FakeClientHandle = {
       client: null as unknown as NotificationClient,
       subject: observer,
+      options: opts,
       connectCalls: 0,
       disconnectCalls: 0,
       pendingPostConnect: [],
@@ -70,7 +73,23 @@ function createFakeFactory(config: FakeFactoryConfig) {
   return { factory, handles }
 }
 
-function createNotifier(timeoutMs?: number): FlowcoreNotifier {
+function createRecordingLogger(): FlowcoreLogger & { calls: Record<keyof FlowcoreLogger, string[]> } {
+  const calls: Record<keyof FlowcoreLogger, string[]> = {
+    debug: [],
+    info: [],
+    warn: [],
+    error: [],
+  }
+  return {
+    calls,
+    debug: (message) => calls.debug.push(message),
+    info: (message) => calls.info.push(message),
+    warn: (message) => calls.warn.push(message),
+    error: (message) => calls.error.push(String(message)),
+  }
+}
+
+function createNotifier(timeoutMs?: number, logger?: FlowcoreLogger): FlowcoreNotifier {
   return new FlowcoreNotifier({
     auth: { apiKey: FAKE_API_KEY, apiKeyId: "testid" },
     dataSource: {
@@ -81,7 +100,7 @@ function createNotifier(timeoutMs?: number): FlowcoreNotifier {
     },
     noTranslation: true,
     timeoutMs,
-    logger: {
+    logger: logger ?? {
       debug: () => {},
       info: () => {},
       warn: () => {},
@@ -430,5 +449,30 @@ describe("FlowcoreNotifier.waitWebSocket — bug fix (v0.20.1)", () => {
     // connect() then throws, so wait() rejects. This is the documented invariant.
     assertStrictEquals(rejected?.message, "connect failed")
     assertEquals(resolvedCleanly, false)
+  })
+
+  it("demotes normal SDK notification lifecycle info logs to debug", async () => {
+    const logger = createRecordingLogger()
+    const { factory } = createFakeFactory({
+      onCreate: (h) => {
+        h.pendingPostConnect.push((handle) => {
+          const sdkLogger = (handle.options as { logger: FlowcoreLogger }).logger
+          sdkLogger.info("WebSocket connection opened.", { source: "sdk" })
+          sdkLogger.info("Connection closed: Code [1000], Reason: Disconnected by user", { source: "sdk" })
+          sdkLogger.info("Attempting reconnection 1 in 1000 ms...", { source: "sdk" })
+          handle.subject.error(new Error("done"))
+        })
+      },
+    })
+    factoryStub = stub(_internals, "createNotificationClient", factory)
+
+    const notifier = createNotifier(20_000, logger)
+    await notifier.wait()
+
+    assertEquals(logger.calls.debug.includes("WebSocket connection opened."), true)
+    assertEquals(logger.calls.debug.includes("Connection closed: Code [1000], Reason: Disconnected by user"), true)
+    assertEquals(logger.calls.info.includes("WebSocket connection opened."), false)
+    assertEquals(logger.calls.info.includes("Connection closed: Code [1000], Reason: Disconnected by user"), false)
+    assertEquals(logger.calls.info.includes("Attempting reconnection 1 in 1000 ms..."), true)
   })
 })


### PR DESCRIPTION
## Summary
- demote normal data-pump cluster lifecycle logs to debug
- demote SDK notification lifecycle info logs at notifier boundary
- bump @flowcore/sdk to 4.2.2

## Tests
- deno fmt --check deno.json src/data-pump/notifier.ts src/data-pump/data-pump-cluster.ts test/tests/notifier.test.ts test/tests/data-pump-cluster.test.ts
- deno test -A test/tests/notifier.test.ts test/tests/data-pump-cluster.test.ts