### PR TITLE
fix: ignore release-please manifest formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ dist
 CHANGELOG.md
 handoff.md
 bun.lock
+.github/workflows/.release-please-manifest.json


### PR DESCRIPTION
## Summary
- ignore release-please manifest in Prettier checks because release-please writes compact JSON

## Test plan
- [x] bun run format:check
- [x] bun run lint
- [x] bun test
- [x] bun run build
- [ ] CI green