### PR TITLE
fix: use trusted publishing for npm release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     types: [published]
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:
@@ -34,7 +35,7 @@ jobs:
         run: bun run lint
       - name: Build for NPM
         run: bun run build
-      - uses: useblacksmith/setup-node@v5
+      - uses: actions/setup-node@v4
         with:
           node-version: "20.x"
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
## Summary
- restore npm trusted publishing path for data-pump release workflow
- keep provenance disabled for Blacksmith runner compatibility

## Test plan
- [x] bun run format:check
- [x] bun run lint
- [x] bun run build
- [ ] CI green