### PR TITLE
feat: add replay stage observability

### DIFF
--- a/src/data-pump/data-pump.ts
+++ b/src/data-pump/data-pump.ts
@@ -3,7 +3,7 @@ import type { FlowcoreEvent } from "@flowcore/sdk"
 import { TimeUuid } from "@flowcore/time-uuid"
 import { format, startOfHour } from "date-fns"
 import { FlowcoreDataSource } from "./data-source.ts"
-import { metrics } from "./metrics.ts"
+import { metrics, ReplayStageObserver } from "./metrics.ts"
 import { FlowcoreNotifier } from "./notifier.ts"
 import { PulseEmitter, type PulseSnapshot } from "./pulse.ts"
 import type {
@@ -98,6 +98,7 @@ export class FlowcoreDataPump {
   private pulledCount = 0
   private processLoopRestartAttempts = 0
   private mainLoopRestartAttempts = 0
+  private readonly replayObserver: ReplayStageObserver
 
   private constructor(
     public readonly dataSource: FlowcoreDataSource,
@@ -106,6 +107,11 @@ export class FlowcoreDataPump {
     private readonly options: FlowcoreDataPumpInnerOptions,
     private readonly logger?: FlowcoreLogger,
   ) {
+    this.replayObserver = new ReplayStageObserver(metrics, {
+      tenant: this.dataSource.tenant,
+      data_core: this.dataSource.dataCore,
+      flow_type: this.dataSource.flowType,
+    })
     this.bufferState = {
       timeBucket: format(startOfHour(utc(new Date())), "yyyyMMddHH0000"),
       eventId: TimeUuid.now().toString(),
@@ -296,8 +302,9 @@ export class FlowcoreDataPump {
     }
   }
 
-  private updateState(eventId?: string) {
-    if (!this.stateManager.setState) {
+  private updateState(eventId?: string): Promise<void> | void {
+    const stateManager = this.stateManager
+    if (!stateManager.setState) {
       return
     }
     const stateEventId = eventId ?? this.buffer[0]?.event.eventId
@@ -306,7 +313,7 @@ export class FlowcoreDataPump {
     }
     const date = TimeUuid.fromString(stateEventId).getDate()
     const timeBucket = format(startOfHour(utc(date)), "yyyyMMddHH0000")
-    return this.stateManager.setState?.({ timeBucket, eventId: stateEventId })
+    return this.replayObserver.observeCheckpoint(() => stateManager.setState!({ timeBucket, eventId: stateEventId }))
   }
 
   private async loop(): Promise<void> {
@@ -315,18 +322,20 @@ export class FlowcoreDataPump {
 
       if (amountToFetch <= 0) {
         this.logger?.info("Buffer is full, waiting for space")
-        await this.waitForBufferThreshold()
+        await this.replayObserver.observeIdle("buffer_full", () => this.waitForBufferThreshold())
         continue
       }
 
       this.logger?.debug(`fetching ${amountToFetch} events from ${this.bufferState.timeBucket}(${this.nextCursor})`)
 
-      const { events, nextCursor } = await this.dataSource.getEvents(
-        this.bufferState,
-        amountToFetch,
-        this.stopAtState?.eventId,
-        this.nextCursor,
-        this.options.includeSensitiveData,
+      const { events, nextCursor } = await this.replayObserver.observeFetch(() =>
+        this.dataSource.getEvents(
+          this.bufferState,
+          amountToFetch,
+          this.stopAtState?.eventId,
+          this.nextCursor,
+          this.options.includeSensitiveData,
+        ),
       )
 
       if (!this.running) {
@@ -370,9 +379,12 @@ export class FlowcoreDataPump {
             this.isLive = true
             this.logger?.debug("Going live...")
             this.abortController = new AbortController()
-            await this.notifier.wait(this.abortController.signal)
+            await this.replayObserver.observeIdle("no_events", () => this.notifier.wait(this.abortController!.signal))
           } else if (this.isLive) {
-            await new Promise((resolve) => setTimeout(resolve, 1000))
+            await this.replayObserver.observeIdle(
+              "no_events",
+              () => new Promise((resolve) => setTimeout(resolve, 1000)),
+            )
           }
         }
       }
@@ -446,21 +458,25 @@ export class FlowcoreDataPump {
     if (!this.running) {
       return
     }
-    const lastEventInBuffer = this.buffer[this.buffer.length - 1]
-    this.buffer = this.buffer.filter((event) => {
-      if (eventIds.includes(event.event.eventId)) {
-        this.incMetricsCounter("acknowledged", event.event.eventType, 1)
-        this.acknowledgedCount++
-        return false
+    const checkpointEventId = this.replayObserver.observeAcknowledgement(() => {
+      const lastEventInBuffer = this.buffer[this.buffer.length - 1]
+      this.buffer = this.buffer.filter((event) => {
+        if (eventIds.includes(event.event.eventId)) {
+          this.incMetricsCounter("acknowledged", event.event.eventType, 1)
+          this.acknowledgedCount++
+          return false
+        }
+        return true
+      })
+
+      if (this.buffer.length <= this.options.bufferSize - this.options.bufferThreshold) {
+        this.waiterBufferThreshold?.()
       }
-      return true
+
+      return this.buffer.length ? undefined : lastEventInBuffer?.event.eventId
     })
 
-    if (this.buffer.length <= this.options.bufferSize - this.options.bufferThreshold) {
-      this.waiterBufferThreshold?.()
-    }
-
-    await this.updateState(this.buffer.length ? undefined : lastEventInBuffer?.event.eventId)
+    await this.updateState(checkpointEventId)
 
     this.updateMetricsGauges()
 
@@ -566,7 +582,9 @@ export class FlowcoreDataPump {
     while (this.running) {
       try {
         const events = await this.reserve(this.options.processor?.concurrency ?? 1)
-        await this.options.processor?.handler(events)
+        await this.replayObserver.observeHandler(events, async () => {
+          await this.options.processor?.handler(events)
+        })
         await this.acknowledge(events.map((event) => event.eventId))
         this.processLoopRestartAttempts = 0
       } catch (error) {
@@ -687,7 +705,7 @@ export class FlowcoreDataPump {
     const promise = new Promise<void>((resolve) => {
       this.waiterEvents = resolve
     })
-    await promise
+    await this.replayObserver.observeIdle("waiting_for_events", () => promise)
   }
 
   private waiterBufferThreshold?: () => void

--- a/src/data-pump/metrics.ts
+++ b/src/data-pump/metrics.ts
@@ -1,66 +1,247 @@
-import PromClient, { Counter, Gauge } from "prom-client"
+import { Counter, Gauge, Histogram, register as defaultPromRegistry, Registry } from "prom-client"
 
-export const dataPumpPromRegistry: PromClient.Registry<"text/plain; version=0.0.4; charset=utf-8"> =
-  new PromClient.Registry()
+export const dataPumpPromRegistry: Registry<"text/plain; version=0.0.4; charset=utf-8"> = new Registry()
 
-const bufferEventCountGauge: Gauge<"tenant" | "data_core" | "flow_type" | "event_type"> = new Gauge({
-  name: "flowcore_data_pump_buffer_events_gauge",
-  help: "The number of events in the buffer",
-  labelNames: ["tenant", "data_core", "flow_type", "event_type"],
-})
+const SOURCE_LABELS = ["tenant", "data_core", "flow_type"] as const
+const EVENT_SOURCE_LABELS = [...SOURCE_LABELS, "event_type"] as const
 
-const bufferReservedEventCountGauge: Gauge<"tenant" | "data_core" | "flow_type" | "event_type"> = new Gauge({
-  name: "flowcore_data_pump_buffer_reserved_events_gauge",
-  help: "The number of reserved events in the buffer",
-  labelNames: ["tenant", "data_core", "flow_type", "event_type"],
-})
+export const REPLAY_DURATION_BUCKETS_SECONDS = [
+  0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 20, 30, 60, 120,
+] as const
+export const REPLAY_EVENT_COUNT_BUCKETS = [1, 10, 50, 100, 250, 500, 1_000, 2_000, 5_000, 10_000] as const
+export const REPLAY_BATCH_SIZE_BUCKETS = ["empty", "1", "2-10", "11-100", "101-1000", "1001+"] as const
+export const REPLAY_FETCH_RESULTS = ["success", "no_events", "error"] as const
+export const REPLAY_STAGE_RESULTS = ["success", "error"] as const
+export const REPLAY_IDLE_REASONS = ["no_events", "buffer_full", "waiting_for_events"] as const
 
-const bufferSizeBytesGauge: Gauge<"tenant" | "data_core" | "flow_type" | "event_type"> = new Gauge({
-  name: "flowcore_data_pump_buffer_size_bytes_gauge",
-  help: "The size of the buffer in bytes",
-  labelNames: ["tenant", "data_core", "flow_type", "event_type"],
-})
+export type ReplayBatchSizeBucket = (typeof REPLAY_BATCH_SIZE_BUCKETS)[number]
+export type ReplayIdleReason = (typeof REPLAY_IDLE_REASONS)[number]
+export type ReplaySourceLabels = {
+  tenant: string
+  data_core: string
+  flow_type: string
+}
 
-const eventsAcknowledgedCounter: Counter<"tenant" | "data_core" | "flow_type" | "event_type"> = new Counter({
-  name: "flowcore_data_pump_events_acknowledged_counter",
-  help: "The number of events acknowledged",
-  labelNames: ["tenant", "data_core", "flow_type", "event_type"],
-})
+export function replayBatchSizeBucket(size: number): ReplayBatchSizeBucket {
+  if (size <= 0) return "empty"
+  if (size === 1) return "1"
+  if (size <= 10) return "2-10"
+  if (size <= 100) return "11-100"
+  if (size <= 1_000) return "101-1000"
+  return "1001+"
+}
 
-const eventsFailedCounter: Counter<"tenant" | "data_core" | "flow_type" | "event_type"> = new Counter({
-  name: "flowcore_data_pump_events_failed_counter",
-  help: "The number of events failed",
-  labelNames: ["tenant", "data_core", "flow_type", "event_type"],
-})
+export function createDataPumpMetrics(registry: Registry, includeDefaultRegistry = false) {
+  const registers = includeDefaultRegistry ? [registry, defaultPromRegistry] : [registry]
+  const bufferEventCountGauge = new Gauge({
+    name: "flowcore_data_pump_buffer_events_gauge",
+    help: "The number of events in the buffer",
+    labelNames: EVENT_SOURCE_LABELS,
+    registers,
+  })
 
-const eventsPulledSizeBytesCounter: Counter<"tenant" | "data_core" | "flow_type" | "event_type"> = new Counter({
-  name: "flowcore_data_pump_events_pulled_size_bytes_counter",
-  help: "The size of the events pulled in bytes",
-  labelNames: ["tenant", "data_core", "flow_type", "event_type"],
-})
+  const bufferReservedEventCountGauge = new Gauge({
+    name: "flowcore_data_pump_buffer_reserved_events_gauge",
+    help: "The number of reserved events in the buffer",
+    labelNames: EVENT_SOURCE_LABELS,
+    registers,
+  })
 
-const sdkCommandsCounter: Counter<"command"> = new Counter({
-  name: "flowcore_data_pump_sdk_commands_counter",
-  help: "The number of SDK commands",
-  labelNames: ["command"],
-})
+  const bufferSizeBytesGauge = new Gauge({
+    name: "flowcore_data_pump_buffer_size_bytes_gauge",
+    help: "The size of the buffer in bytes",
+    labelNames: EVENT_SOURCE_LABELS,
+    registers,
+  })
 
-dataPumpPromRegistry.registerMetric(bufferEventCountGauge)
-dataPumpPromRegistry.registerMetric(bufferReservedEventCountGauge)
-dataPumpPromRegistry.registerMetric(bufferSizeBytesGauge)
-dataPumpPromRegistry.registerMetric(eventsAcknowledgedCounter)
-dataPumpPromRegistry.registerMetric(eventsFailedCounter)
-dataPumpPromRegistry.registerMetric(eventsPulledSizeBytesCounter)
-dataPumpPromRegistry.registerMetric(sdkCommandsCounter)
+  const eventsAcknowledgedCounter = new Counter({
+    name: "flowcore_data_pump_events_acknowledged_counter",
+    help: "The number of events acknowledged",
+    labelNames: EVENT_SOURCE_LABELS,
+    registers,
+  })
 
-export const metrics = {
-  bufferEventCountGauge,
-  bufferReservedEventCountGauge,
-  bufferSizeBytesGauge,
-  eventsAcknowledgedCounter,
-  eventsFailedCounter,
-  eventsPulledSizeBytesCounter,
-  sdkCommandsCounter,
+  const eventsFailedCounter = new Counter({
+    name: "flowcore_data_pump_events_failed_counter",
+    help: "The number of events failed",
+    labelNames: EVENT_SOURCE_LABELS,
+    registers,
+  })
+
+  const eventsPulledSizeBytesCounter = new Counter({
+    name: "flowcore_data_pump_events_pulled_size_bytes_counter",
+    help: "The size of the events pulled in bytes",
+    labelNames: EVENT_SOURCE_LABELS,
+    registers,
+  })
+
+  const sdkCommandsCounter = new Counter({
+    name: "flowcore_data_pump_sdk_commands_counter",
+    help: "The number of SDK commands",
+    labelNames: ["command"] as const,
+    registers,
+  })
+
+  const replayFetchDuration = new Histogram({
+    name: "flowcore_data_pump_replay_fetch_duration_seconds",
+    help: "Replay event fetch duration in seconds",
+    labelNames: [...SOURCE_LABELS, "result"] as const,
+    buckets: [...REPLAY_DURATION_BUCKETS_SECONDS],
+    registers,
+  })
+
+  const replayFetchEvents = new Histogram({
+    name: "flowcore_data_pump_replay_fetch_events",
+    help: "Number of events returned by a replay fetch",
+    labelNames: SOURCE_LABELS,
+    buckets: [...REPLAY_EVENT_COUNT_BUCKETS],
+    registers,
+  })
+
+  const replayHandlerDuration = new Histogram({
+    name: "flowcore_data_pump_replay_handler_duration_seconds",
+    help: "Replay handler duration in seconds",
+    labelNames: [...SOURCE_LABELS, "result", "batch_size_bucket"] as const,
+    buckets: [...REPLAY_DURATION_BUCKETS_SECONDS],
+    registers,
+  })
+
+  const replayAcknowledgementDuration = new Histogram({
+    name: "flowcore_data_pump_replay_acknowledgement_duration_seconds",
+    help: "Replay acknowledgement duration in seconds, excluding checkpointing",
+    labelNames: [...SOURCE_LABELS, "result"] as const,
+    buckets: [...REPLAY_DURATION_BUCKETS_SECONDS],
+    registers,
+  })
+
+  const replayCheckpointDuration = new Histogram({
+    name: "flowcore_data_pump_replay_checkpoint_duration_seconds",
+    help: "Replay state checkpoint duration in seconds",
+    labelNames: [...SOURCE_LABELS, "result"] as const,
+    buckets: [...REPLAY_DURATION_BUCKETS_SECONDS],
+    registers,
+  })
+
+  const replayIdleDuration = new Histogram({
+    name: "flowcore_data_pump_replay_idle_duration_seconds",
+    help: "Time the replay loop spends idle",
+    labelNames: [...SOURCE_LABELS, "reason"] as const,
+    buckets: [...REPLAY_DURATION_BUCKETS_SECONDS, 300],
+    registers,
+  })
+
+  return {
+    bufferEventCountGauge,
+    bufferReservedEventCountGauge,
+    bufferSizeBytesGauge,
+    eventsAcknowledgedCounter,
+    eventsFailedCounter,
+    eventsPulledSizeBytesCounter,
+    sdkCommandsCounter,
+    replayFetchDuration,
+    replayFetchEvents,
+    replayHandlerDuration,
+    replayAcknowledgementDuration,
+    replayCheckpointDuration,
+    replayIdleDuration,
+  }
+}
+
+export type DataPumpMetrics = ReturnType<typeof createDataPumpMetrics>
+
+export const metrics = createDataPumpMetrics(dataPumpPromRegistry, true)
+
+export class ReplayStageObserver {
+  public constructor(
+    private readonly stageMetrics: DataPumpMetrics,
+    private readonly source: ReplaySourceLabels,
+    private readonly now: () => number = () => performance.now(),
+  ) {}
+
+  public async observeFetch<T extends { events: unknown[] }>(operation: () => Promise<T>): Promise<T> {
+    const startedAt = this.now()
+    try {
+      const result = await operation()
+      this.stageMetrics.replayFetchDuration.observe(
+        { ...this.source, result: result.events.length ? "success" : "no_events" },
+        this.elapsedSeconds(startedAt),
+      )
+      this.stageMetrics.replayFetchEvents.observe(this.source, result.events.length)
+      return result
+    } catch (error) {
+      this.stageMetrics.replayFetchDuration.observe({ ...this.source, result: "error" }, this.elapsedSeconds(startedAt))
+      throw error
+    }
+  }
+
+  public async observeHandler<T>(events: unknown[], operation: () => Promise<T>): Promise<T> {
+    const startedAt = this.now()
+    const batchSize = replayBatchSizeBucket(events.length)
+    try {
+      const result = await operation()
+      this.stageMetrics.replayHandlerDuration.observe(
+        { ...this.source, result: "success", batch_size_bucket: batchSize },
+        this.elapsedSeconds(startedAt),
+      )
+      return result
+    } catch (error) {
+      this.stageMetrics.replayHandlerDuration.observe(
+        { ...this.source, result: "error", batch_size_bucket: batchSize },
+        this.elapsedSeconds(startedAt),
+      )
+      throw error
+    }
+  }
+
+  public observeAcknowledgement<T>(operation: () => T): T {
+    const startedAt = this.now()
+    try {
+      const result = operation()
+      this.stageMetrics.replayAcknowledgementDuration.observe(
+        { ...this.source, result: "success" },
+        this.elapsedSeconds(startedAt),
+      )
+      return result
+    } catch (error) {
+      this.stageMetrics.replayAcknowledgementDuration.observe(
+        { ...this.source, result: "error" },
+        this.elapsedSeconds(startedAt),
+      )
+      throw error
+    }
+  }
+
+  public observeCheckpoint<T>(operation: () => Promise<T> | T): Promise<T> {
+    return this.observeResult(this.stageMetrics.replayCheckpointDuration, operation)
+  }
+
+  public async observeIdle<T>(reason: ReplayIdleReason, operation: () => Promise<T>): Promise<T> {
+    const startedAt = this.now()
+    try {
+      return await operation()
+    } finally {
+      this.stageMetrics.replayIdleDuration.observe({ ...this.source, reason }, this.elapsedSeconds(startedAt))
+    }
+  }
+
+  private async observeResult<T>(
+    histogram: Histogram<"tenant" | "data_core" | "flow_type" | "result">,
+    operation: () => Promise<T> | T,
+  ): Promise<T> {
+    const startedAt = this.now()
+    try {
+      const result = await operation()
+      histogram.observe({ ...this.source, result: "success" }, this.elapsedSeconds(startedAt))
+      return result
+    } catch (error) {
+      histogram.observe({ ...this.source, result: "error" }, this.elapsedSeconds(startedAt))
+      throw error
+    }
+  }
+
+  private elapsedSeconds(startedAt: number): number {
+    return Math.max(0, this.now() - startedAt) / 1_000
+  }
 }
 
 // #region Cluster Metrics

--- a/test/tests/replay-observability.test.ts
+++ b/test/tests/replay-observability.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, it } from "bun:test"
+import type { EventListOutput, FlowcoreEvent } from "@flowcore/sdk"
+import { TimeUuid } from "@flowcore/time-uuid"
+import { register as defaultPromRegistry, Registry } from "prom-client"
+import { FlowcoreDataPump } from "../../src/data-pump/data-pump.ts"
+import { FlowcoreDataSource } from "../../src/data-pump/data-source.ts"
+import type { FlowcoreDataPumpState, FlowcoreDataPumpStateManager } from "../../src/data-pump/types.ts"
+import {
+  REPLAY_BATCH_SIZE_BUCKETS,
+  REPLAY_DURATION_BUCKETS_SECONDS,
+  REPLAY_FETCH_RESULTS,
+  REPLAY_IDLE_REASONS,
+  REPLAY_STAGE_RESULTS,
+  ReplayStageObserver,
+  createDataPumpMetrics,
+  metrics,
+  replayBatchSizeBucket,
+} from "../../src/data-pump/metrics.ts"
+
+const source = {
+  tenant: "test-tenant",
+  data_core: "test-data-core",
+  flow_type: "test-flow-type",
+}
+
+function metricValue(
+  values: ReadonlyArray<{
+    labels: Partial<Record<string, string | number>>
+    value: number
+    metricName?: string
+  }>,
+  expectedLabels: Record<string, string>,
+  metricName?: string,
+): number | undefined {
+  return values.find(
+    (entry) =>
+      (!metricName || entry.metricName === metricName) &&
+      Object.entries(expectedLabels).every(([name, value]) => entry.labels[name] === value),
+  )?.value
+}
+
+describe("replay observability metrics", () => {
+  it("registers replay stage and existing bounded buffer metrics in an isolated registry", () => {
+    const registry = new Registry()
+    const isolatedMetrics = createDataPumpMetrics(registry)
+
+    expect(registry.getMetricsAsArray().map((metric) => metric.name)).toEqual(
+      expect.arrayContaining([
+        "flowcore_data_pump_replay_fetch_duration_seconds",
+        "flowcore_data_pump_replay_fetch_events",
+        "flowcore_data_pump_replay_handler_duration_seconds",
+        "flowcore_data_pump_replay_acknowledgement_duration_seconds",
+        "flowcore_data_pump_replay_checkpoint_duration_seconds",
+        "flowcore_data_pump_replay_idle_duration_seconds",
+        "flowcore_data_pump_buffer_events_gauge",
+        "flowcore_data_pump_buffer_reserved_events_gauge",
+        "flowcore_data_pump_buffer_size_bytes_gauge",
+      ]),
+    )
+
+    expect(defaultPromRegistry.getSingleMetric("flowcore_data_pump_buffer_events_gauge")).toBeDefined()
+    expect(defaultPromRegistry.getSingleMetric("flowcore_data_pump_replay_fetch_duration_seconds")).toBeDefined()
+    expect((isolatedMetrics.replayFetchDuration as unknown as { labelNames: string[] }).labelNames).toEqual([
+      "tenant",
+      "data_core",
+      "flow_type",
+      "result",
+    ])
+  })
+
+  it("uses finite batch-size buckets and duration buckets that cover slow replays", () => {
+    expect(REPLAY_BATCH_SIZE_BUCKETS).toEqual(["empty", "1", "2-10", "11-100", "101-1000", "1001+"])
+    expect(REPLAY_FETCH_RESULTS).toEqual(["success", "no_events", "error"])
+    expect(REPLAY_STAGE_RESULTS).toEqual(["success", "error"])
+    expect(REPLAY_IDLE_REASONS).toEqual(["no_events", "buffer_full", "waiting_for_events"])
+    expect([0, 1, 2, 10, 11, 100, 101, 1000, 1001].map(replayBatchSizeBucket)).toEqual([
+      "empty",
+      "1",
+      "2-10",
+      "2-10",
+      "11-100",
+      "11-100",
+      "101-1000",
+      "101-1000",
+      "1001+",
+    ])
+    expect(REPLAY_DURATION_BUCKETS_SECONDS).toContain(10)
+    expect(REPLAY_DURATION_BUCKETS_SECONDS).toContain(60)
+    expect(REPLAY_DURATION_BUCKETS_SECONDS[REPLAY_DURATION_BUCKETS_SECONDS.length - 1]).toBeGreaterThanOrEqual(120)
+  })
+
+  it("observes fetch duration, finite results, and returned event counts", async () => {
+    const registry = new Registry()
+    const stageMetrics = createDataPumpMetrics(registry)
+    const clockValues = [1_000, 8_000, 10_000, 12_000, 20_000, 23_000]
+    const observer = new ReplayStageObserver(stageMetrics, source, () => clockValues.shift()!)
+
+    await observer.observeFetch(() => Promise.resolve({ events: [{}, {}] }))
+    await observer.observeFetch(() => Promise.resolve({ events: [] }))
+    await expect(observer.observeFetch(() => Promise.reject(new Error("fetch failed")))).rejects.toThrow("fetch failed")
+
+    const duration = await stageMetrics.replayFetchDuration.get()
+    expect(metricValue(duration.values, { ...source, result: "success", le: "+Inf" })).toBe(1)
+    expect(metricValue(duration.values, { ...source, result: "no_events", le: "+Inf" })).toBe(1)
+    expect(metricValue(duration.values, { ...source, result: "error", le: "+Inf" })).toBe(1)
+    expect(
+      metricValue(
+        duration.values,
+        { ...source, result: "success" },
+        "flowcore_data_pump_replay_fetch_duration_seconds_sum",
+      ),
+    ).toBe(7)
+
+    const returned = await stageMetrics.replayFetchEvents.get()
+    expect(metricValue(returned.values, { ...source, le: "+Inf" })).toBe(2)
+    expect(metricValue(returned.values, source, "flowcore_data_pump_replay_fetch_events_sum")).toBe(2)
+  })
+
+  it("observes handler result with a finite batch-size bucket", async () => {
+    const registry = new Registry()
+    const stageMetrics = createDataPumpMetrics(registry)
+    const clockValues = [0, 500, 1_000, 2_500]
+    const observer = new ReplayStageObserver(stageMetrics, source, () => clockValues.shift()!)
+
+    await observer.observeHandler(new Array(25), () => Promise.resolve())
+    await expect(
+      observer.observeHandler(new Array(1_001), () => Promise.reject(new Error("handler failed"))),
+    ).rejects.toThrow("handler failed")
+
+    const duration = await stageMetrics.replayHandlerDuration.get()
+    expect(
+      metricValue(duration.values, { ...source, result: "success", batch_size_bucket: "11-100", le: "+Inf" }),
+    ).toBe(1)
+    expect(metricValue(duration.values, { ...source, result: "error", batch_size_bucket: "1001+", le: "+Inf" })).toBe(1)
+  })
+
+  it("observes acknowledgement, checkpoint, and bounded idle reasons", async () => {
+    const registry = new Registry()
+    const stageMetrics = createDataPumpMetrics(registry)
+    let now = 0
+    const observer = new ReplayStageObserver(stageMetrics, source, () => {
+      now += 250
+      return now
+    })
+
+    observer.observeAcknowledgement(() => undefined)
+    expect(() =>
+      observer.observeAcknowledgement(() => {
+        throw new Error("ack failed")
+      }),
+    ).toThrow("ack failed")
+    await observer.observeCheckpoint(() => Promise.resolve())
+    await expect(observer.observeCheckpoint(() => Promise.reject(new Error("checkpoint failed")))).rejects.toThrow(
+      "checkpoint failed",
+    )
+    await observer.observeIdle("no_events", () => Promise.resolve())
+    await observer.observeIdle("buffer_full", () => Promise.resolve())
+    await observer.observeIdle("waiting_for_events", () => Promise.resolve())
+
+    const acknowledgement = await stageMetrics.replayAcknowledgementDuration.get()
+    expect(metricValue(acknowledgement.values, { ...source, result: "success", le: "+Inf" })).toBe(1)
+    expect(metricValue(acknowledgement.values, { ...source, result: "error", le: "+Inf" })).toBe(1)
+
+    const checkpoint = await stageMetrics.replayCheckpointDuration.get()
+    expect(metricValue(checkpoint.values, { ...source, result: "success", le: "+Inf" })).toBe(1)
+    expect(metricValue(checkpoint.values, { ...source, result: "error", le: "+Inf" })).toBe(1)
+
+    const idle = await stageMetrics.replayIdleDuration.get()
+    expect(metricValue(idle.values, { ...source, reason: "no_events", le: "+Inf" })).toBe(1)
+    expect(metricValue(idle.values, { ...source, reason: "buffer_full", le: "+Inf" })).toBe(1)
+    expect(metricValue(idle.values, { ...source, reason: "waiting_for_events", le: "+Inf" })).toBe(1)
+  })
+
+  it("preserves the receiver when checkpointing through a class-based state manager", async () => {
+    class ClassBasedStateManager implements FlowcoreDataPumpStateManager {
+      public state: FlowcoreDataPumpState | null = null
+
+      public getState(): FlowcoreDataPumpState | null {
+        return this.state
+      }
+
+      public setState(state: FlowcoreDataPumpState): void {
+        this.state = state
+      }
+    }
+
+    const stateManager = new ClassBasedStateManager()
+    const eventId = TimeUuid.now().toString()
+    const pump = FlowcoreDataPump.create({
+      auth: { apiKey: "fc_testid_testsecret" },
+      dataSource: {
+        tenant: "test-tenant",
+        dataCore: "test-data-core",
+        flowType: "test-flow-type",
+        eventTypes: ["test.created.0"],
+      },
+      stateManager,
+      notifier: { type: "poller", intervalMs: 60_000 },
+      noTranslation: true,
+    })
+
+    await (pump as unknown as { updateState: (checkpointEventId: string) => Promise<void> | void }).updateState(eventId)
+
+    expect(stateManager.state?.eventId).toBe(eventId)
+  })
+
+  it("wires fetch, handler, acknowledgement, checkpoint, and buffer observations into the pump", async () => {
+    const tenant = `replay-observability-${crypto.randomUUID()}`
+    const wiredSource = { tenant, data_core: "test-data-core", flow_type: "test-flow-type" }
+    const eventType = "test.created.0"
+    const eventId = TimeUuid.now().toString()
+    const event: FlowcoreEvent = {
+      eventId,
+      timeBucket: "20260804120000",
+      tenant,
+      dataCoreId: wiredSource.data_core,
+      flowType: wiredSource.flow_type,
+      eventType,
+      metadata: {},
+      validTime: new Date().toISOString(),
+      payload: { measured: true },
+    }
+
+    class SinglePageDataSource extends FlowcoreDataSource {
+      private fetched = false
+
+      public override getClosestTimeBucket(): Promise<string> {
+        return Promise.resolve("20260804120000")
+      }
+
+      public override getNextTimeBucket(): Promise<null> {
+        return Promise.resolve(null)
+      }
+
+      public override getEvents(): Promise<EventListOutput> {
+        if (this.fetched) return new Promise(() => {})
+        this.fetched = true
+        return Promise.resolve({ events: [event], nextCursor: undefined })
+      }
+    }
+
+    const dataSource = new SinglePageDataSource({
+      auth: { apiKey: "fc_testid_testsecret" },
+      dataSource: {
+        tenant,
+        dataCore: wiredSource.data_core,
+        flowType: wiredSource.flow_type,
+        eventTypes: [eventType],
+      },
+      noTranslation: true,
+    })
+
+    let pump!: FlowcoreDataPump
+    let completed!: () => void
+    let acknowledgementObservedBeforeCheckpoint = false
+    let checkpointObservedDuringCheckpoint = false
+    const completion = new Promise<void>((resolve) => {
+      completed = resolve
+    })
+    pump = FlowcoreDataPump.create(
+      {
+        auth: { apiKey: "fc_testid_testsecret" },
+        dataSource: {
+          tenant,
+          dataCore: wiredSource.data_core,
+          flowType: wiredSource.flow_type,
+          eventTypes: [eventType],
+        },
+        bufferSize: 1,
+        stateManager: {
+          getState: () => ({ timeBucket: "20260804120000", eventId }),
+          setState: async () => {
+            const acknowledgement = await metrics.replayAcknowledgementDuration.get()
+            acknowledgementObservedBeforeCheckpoint =
+              metricValue(acknowledgement.values, { ...wiredSource, result: "success", le: "+Inf" }) === 1
+            const checkpoint = await metrics.replayCheckpointDuration.get()
+            checkpointObservedDuringCheckpoint =
+              metricValue(checkpoint.values, { ...wiredSource, result: "success", le: "+Inf" }) === 1
+            pump.stop()
+            setTimeout(completed, 0)
+          },
+        },
+        processor: { concurrency: 1, handler: () => Promise.resolve() },
+        notifier: { type: "poller", intervalMs: 60_000 },
+        noTranslation: true,
+      },
+      dataSource,
+    )
+
+    void pump.start(() => {})
+    await Promise.race([
+      completion,
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error("pump did not complete")), 1_000)),
+    ])
+
+    const fetchDuration = await metrics.replayFetchDuration.get()
+    expect(metricValue(fetchDuration.values, { ...wiredSource, result: "success", le: "+Inf" })).toBe(1)
+    const handlerDuration = await metrics.replayHandlerDuration.get()
+    expect(
+      metricValue(handlerDuration.values, {
+        ...wiredSource,
+        result: "success",
+        batch_size_bucket: "1",
+        le: "+Inf",
+      }),
+    ).toBe(1)
+    const acknowledgementDuration = await metrics.replayAcknowledgementDuration.get()
+    expect(metricValue(acknowledgementDuration.values, { ...wiredSource, result: "success", le: "+Inf" })).toBe(1)
+    expect(acknowledgementObservedBeforeCheckpoint).toBe(true)
+    expect(checkpointObservedDuringCheckpoint).toBe(false)
+    const checkpointDuration = await metrics.replayCheckpointDuration.get()
+    expect(metricValue(checkpointDuration.values, { ...wiredSource, result: "success", le: "+Inf" })).toBe(1)
+
+    const bufferEvents = await metrics.bufferEventCountGauge.get()
+    expect(metricValue(bufferEvents.values, { ...wiredSource, event_type: eventType })).toBe(0)
+    const bufferBytes = await metrics.bufferSizeBytesGauge.get()
+    expect(metricValue(bufferBytes.values, { ...wiredSource, event_type: eventType })).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

Adds Phase 1 replay-stage observability to `@flowcore/data-pump` without changing replay algorithms or concurrency.

### Measurement added

- fetch duration/result and returned event counts
- handler duration/result with bounded batch-size buckets
- acknowledgement duration/result
- checkpoint duration/result
- idle duration with finite reasons
- duration buckets covering slow replays through 120 seconds

Existing metric names, exports, and private/default registry behavior are preserved. New result/reason/batch labels use finite enumerations.

This PR intentionally does **not** change buffer algorithms, acknowledgement membership checks, bucket traversal, prefetch, or in-flight concurrency. It establishes the baseline for the next optimization PR.

## Verification

- `bun test` — **61 passed, 0 failed**
- `bun run lint` — pass
- `bun run typecheck` — pass
- `bun run format:check` — pass
- `bun run build` — pass
- `git diff --check` — pass
- class-based state-manager receiver regression covered
- independent spec review — pass
- independent code-quality/security review — approved

## Research

- https://usable.dev/dashboard/workspaces/60c10ca2-4115-4c1a-b6d7-04ac39fd3938/fragments/d8309cc9-d4ad-4930-b9ab-ffd702a821ad
- https://usable.dev/dashboard/workspaces/60c10ca2-4115-4c1a-b6d7-04ac39fd3938/fragments/3ac9bdcc-2e35-4e72-9078-8bfefee9a8e6
